### PR TITLE
Add action for automatically deploying to gh-pages

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy on GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: yarn install, yarn build
+      run: |
+        yarn --frozen-lockfile
+        yarn build
+        echo 'aragon.org' > dist/CNAME
+      env:
+        NODE_ENV: 'production'
+    - name: push to gh-pages
+      uses: peaceiris/actions-gh-pages@v2
+      env:
+        ACTIONS_DEPLOY_KEY: ${{ secrets.GH_PAGES_ACTIONS_DEPLOY_KEY }}
+        PUBLISH_BRANCH: gh-pages
+        PUBLISH_DIR: ./dist


### PR DESCRIPTION
Similar to anj.aragon.org.

Deploy key and secrets have been set up.